### PR TITLE
Automatic Windows Build

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -53,7 +53,7 @@ jobs:
         $src = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}\bin"
         $windeployqt = Join-Path $src windeployqt.exe
 
-        & "$windeployqt" (Join-Path $pwd build\release)
+        & "$windeployqt" --release --no-translations (Join-Path $pwd build\release)
 
         #'Qt6Gui.dll', 'Qt6Core.dll', 'Qt6Widgets.dll' | ForEach-Object {
         #  Copy-Item (Join-Path $src $_) .\build\release

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,4 +1,4 @@
-name: Windows C++ Qt Build
+name: Windows Build
 
 on:
   push:
@@ -78,6 +78,6 @@ jobs:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "latest"
         prerelease: true
-        title: "Automatic Build ${{ github.sha }}"
+        title: "Automatic Build"
         files: |
           OpenSprite-latest.zip

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -22,8 +22,8 @@ jobs:
     - name: Install Qt
       run: |
         Write-Host 'Installing Qt ...'
-        #aqt install-qt windows desktop 6.2.0 win64_msvc2019_x64 -O C:\Qt
-        aqt list-qt windows desktop --arch 6.2.0
+        #aqt list-qt windows desktop --arch 6.2.0
+        aqt install-qt windows desktop 6.2.0 win64_msvc2019_64 -O C:\Qt
 
     - name: Run qmake
       run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -13,9 +13,6 @@ jobs:
 
     runs-on: windows-latest
 
-    env:
-      QT_PATH: C:\Qt\${{ env.QT_VERSION }}\${{ env.PLATFORM }}
-
     steps:
     - uses: actions/checkout@v3
 
@@ -33,10 +30,10 @@ jobs:
         aqt install-qt windows desktop $Env:QT_VERSION "win64_${Env:PLATFORM}" -O C:\Qt
 
     - name: List Dir
-      run: Get-ChildItem $Env:QT_PATH
+      run: Get-ChildItem "C:\Qt\${Env:QT_VERSION}\${Env:PLATFORM}"
 
     - name: Run qmake
       run: |
         Write-Host 'Running qmake ...'
-        $Env:PATH = "${Env:QT_PATH};${Env:PATH}"
+        $Env:PATH = ""C:\Qt\${Env:QT_VERSION}\${Env:PLATFORM}";${Env:PATH}"
         qmake --help

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -7,7 +7,7 @@ on:
 env:
   QT_VERSION: 6.2.0
   PLATFORM: msvc2019_64
-  QT_PATH: C:\Qt\$QT_VERSION\$PLATFORM
+  QT_PATH: C:\Qt\${{ $QT_VERSION }}\${{ $PLATFORM }}
 
 jobs:
   build:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -48,4 +48,4 @@ jobs:
     - name: List artifacts
       run: |
         Get-ChildItem . -Recurse
-        Get-ChildItem C:\tmp -Recurse
+        #Get-ChildItem C:\tmp -Recurse

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -22,7 +22,8 @@ jobs:
     - name: Install Qt
       run: |
         Write-Host 'Installing Qt ...'
-        aqt install-qt windows desktop 6.2.0 win64_msvc2019_x64 -O C:\Qt
+        #aqt install-qt windows desktop 6.2.0 win64_msvc2019_x64 -O C:\Qt
+        aqt list-qt windows desktop --arch 6.2.0
 
     - name: Run qmake
       run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -44,8 +44,16 @@ jobs:
         $Env:PATH = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}\bin;${Env:PATH}"
         #qmake --help
         #Write-Host
-        qmake -makefile -Wall -d OpenSprite.pro
+        qmake -makefile -Wall -tp vc OpenSprite.pro
         make
+
+    - name: List qmake stuff
+      run: |
+        Get-ChildItem . -Recurse
+
+    - name: Build
+      run: |
+        msbuild
 
     - name: List artifacts
       run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -44,10 +44,6 @@ jobs:
         # Generate MSBuild VC++ project
         qmake -Wall -tp vc OpenSprite.pro
 
-    - name: List qmake artifacts
-      run: |
-        Get-ChildItem . -Recurse
-
     - name: Build
       run: |
         msbuild OpenSprite.vcxproj -property:Configuration=Release
@@ -57,7 +53,7 @@ jobs:
         $src = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}\bin"
         $windeployqt = Join-Path $src windeployqt.exe
 
-        & "$windeployqt" .\build\release
+        & "$windeployqt" (Join-Path $pwd build\release)
 
         #'Qt6Gui.dll', 'Qt6Core.dll', 'Qt6Widgets.dll' | ForEach-Object {
         #  Copy-Item (Join-Path $src $_) .\build\release

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [ "cicd" ]
 
+env:
+  QT_VERSION: 6.2.0
+  PLATFORM: msvc2019_64
+  QT_PATH: C:\Qt\$QT_VERSION\$PLATFORM
+
 jobs:
   build:
 
@@ -22,17 +27,14 @@ jobs:
     - name: Install Qt
       run: |
         Write-Host 'Installing Qt ...'
-        #aqt list-qt windows desktop --arch 6.2.0
-        aqt install-qt windows desktop 6.2.0 win64_msvc2019_64 -O C:\Qt
+        #aqt list-qt windows desktop --arch $Env:QT_VERSION
+        aqt install-qt windows desktop $Env:QT_VERSION "win64_${Env:PLATFORM}" -O C:\Qt
 
-    - name: List Dir 1
-      run: Get-ChildItem C:\Qt
-
-    - name: List Dir 2
-      run: Get-ChildItem C:\Qt\6.2.0
+    - name: List Dir
+      run: Get-ChildItem $Env:QT_PATH
 
     - name: Run qmake
       run: |
         Write-Host 'Running qmake ...'
-        $Env:PATH = "C:\Qt\6.2.0;$($Env:PATH)"
+        $Env:PATH = "${Env:QT_PATH};${Env:PATH}"
         qmake --help

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -29,12 +29,9 @@ jobs:
         #aqt list-qt windows desktop --arch $Env:QT_VERSION
         aqt install-qt windows desktop $Env:QT_VERSION "win64_${Env:PLATFORM}" -O C:\Qt
 
-    - name: List Dir
-      run: Get-ChildItem "C:\Qt\${Env:QT_VERSION}\${Env:PLATFORM}\bin"
-
     - name: Run qmake
       run: |
         Write-Host 'Running qmake ...'
         $Env:PATH = "C:\Qt\${Env:QT_VERSION}\${Env:PLATFORM}\bin;${Env:PATH}"
-        qmake --help
-        #qmake OpenSprite.pro
+        #qmake --help
+        qmake

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -43,7 +43,7 @@ jobs:
         $Env:PATH = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}\bin;${Env:PATH}"
         #qmake --help
         #Write-Host
-        qmake -makefile OpenSprite.pro
+        qmake -makefile -Wall -d OpenSprite.pro
 
     - name: List artifacts
       run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -44,7 +44,7 @@ jobs:
         $Env:PATH = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}\bin;${Env:PATH}"
         #qmake --help
         #Write-Host
-        qmake -makefile -Wall -tp vc OpenSprite.pro
+        qmake -Wall -tp vc OpenSprite.pro
         make
 
     - name: List qmake stuff

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -44,7 +44,7 @@ jobs:
         $Env:PATH = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}\bin;${Env:PATH}"
         qmake --help
         Write-Host
-        qmake -Wall -tp OpenSprite.pro
+        qmake -Wall -tp vc OpenSprite.pro
 
     - name: List qmake stuff
       run: |
@@ -52,7 +52,7 @@ jobs:
 
     - name: Build
       run: |
-        cmake
+        #cmake
         msbuild
 
     - name: List artifacts

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -7,12 +7,14 @@ on:
 env:
   QT_VERSION: 6.2.0
   PLATFORM: msvc2019_64
-  QT_PATH: C:\Qt\${{ env.QT_VERSION }}\${{ env.PLATFORM }}
 
 jobs:
   build:
 
     runs-on: windows-latest
+
+    env:
+      QT_PATH: C:\Qt\${{ env.QT_VERSION }}\${{ env.PLATFORM }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -46,16 +46,21 @@ jobs:
         Write-Host
         qmake -Wall -tp vc OpenSprite.pro
 
-    - name: List qmake stuff
+    - name: List qmake artifacts
       run: |
         Get-ChildItem . -Recurse
 
     - name: Build
       run: |
-        #cmake
-        msbuild
+        msbuild OpenSprite.vcxproj -property:Configuration=Release
 
     - name: List artifacts
       run: |
         Get-ChildItem . -Recurse
         #Get-ChildItem C:\tmp -Recurse
+
+    - name: Upload executable artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: OpenSprite.exe
+        path: build/release/OpenSprite.exe

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -7,7 +7,7 @@ on:
       - cicd
 
 env:
-  QT_VERSION: 6.2.0
+  QT_VERSION: 6.5.0
   AQT_PLATFORM: msvc2019_64
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
       with:
         compiler: msvc
         vcvarsall: true
-        make: true
+        cmake: true
 
     - name: Download aqtinstall
       run: |
@@ -42,10 +42,9 @@ jobs:
       run: |
         Write-Host 'Running qmake ...'
         $Env:PATH = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}\bin;${Env:PATH}"
-        #qmake --help
-        #Write-Host
-        qmake -Wall -tp vc OpenSprite.pro
-        make
+        qmake --help
+        Write-Host
+        qmake -Wall -tp OpenSprite.pro
 
     - name: List qmake stuff
       run: |
@@ -53,6 +52,7 @@ jobs:
 
     - name: Build
       run: |
+        cmake
         msbuild
 
     - name: List artifacts

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
 
-    runs-on: windows
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -81,4 +81,4 @@ jobs:
         prerelease: true
         title: "Automatic Build"
         files: |
-          "${{ env.ARCHIVE_NAME }}.zip"
+          ${{ env.ARCHIVE_NAME }}.zip

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,19 @@
+name: Windows C++ Qt Build
+
+on:
+  push:
+    branches: [ "cicd" ]
+
+jobs:
+  build:
+
+    runs-on: windows
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Download aqtinstall
+      run: echo Download aqtinstall
+    - name: Install Qt
+      run: echo Installing Qt ...
+    - name: Run qmake
+      run: echo Running qmake ...

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -11,9 +11,20 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
     - name: Download aqtinstall
-      run: echo Download aqtinstall
+      run: |
+        Write-Host 'Downloading  aqtinstall ...'
+        $src = 'https://github.com/miurahr/aqtinstall/releases/download/v3.1.6/aqt_x64_signed.exe'
+        $target = 'C:\Windows\System32\aqt.exe'
+        Invoke-WebRequest -Uri $src -OutFile $target
+
     - name: Install Qt
-      run: echo Installing Qt ...
+      run: |
+        Write-Host 'Installing Qt ...'
+        aqt install-qt windows desktop 6.2.0 win64_msvc2019_x64 -O C:\Qt
+
     - name: Run qmake
-      run: echo Running qmake ...
+      run: |
+        Write-Host 'Running qmake ...'
+        qmake --help

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -2,7 +2,9 @@ name: Windows C++ Qt Build
 
 on:
   push:
-    branches: [ "cicd" ]
+    branches:
+      - main
+      - cicd
 
 env:
   QT_VERSION: 6.2.0
@@ -39,8 +41,9 @@ jobs:
       run: |
         Write-Host 'Running qmake ...'
         $Env:PATH = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}\bin;${Env:PATH}"
-        #qmake --help
-        qmake
+        qmake --help
+        Write-Host
+        qmake -makefile OpenSprite.pro
 
     - name: List artifacts
       run: Get-ChildItem . -Recurse

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -50,7 +50,7 @@ jobs:
 
     - name: List Qt6 binaries
       run: |
-        $src = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}\bin"
+        $src = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}"
         Get-ChildItem $src -Recurse
 
     - name: Build

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -23,6 +23,7 @@ jobs:
       with:
         compiler: msvc
         vcvarsall: true
+        make: true
 
     - name: Download aqtinstall
       run: |
@@ -44,6 +45,7 @@ jobs:
         #qmake --help
         #Write-Host
         qmake -makefile -Wall -d OpenSprite.pro
+        make
 
     - name: List artifacts
       run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -53,6 +53,13 @@ jobs:
       run: |
         msbuild OpenSprite.vcxproj -property:Configuration=Release
 
+    - name: Provision Qt6 libraries
+      run: |
+        $src = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}\bin"
+        'Qt6Gui.dll', 'Qt6Core.dll', 'Qt6Widgets.dll' | ForEach-Object {
+          Copy-Item (Join-Path $src $_) .\build\release
+        }
+
     - name: List artifacts
       run: |
         Get-ChildItem . -Recurse
@@ -61,5 +68,7 @@ jobs:
     - name: Upload executable artifact
       uses: actions/upload-artifact@v3
       with:
-        name: OpenSprite.exe
-        path: build/release/OpenSprite.exe
+        name: OpenSprite-latest.zip
+        path: |
+          build/release/OpenSprite.exe
+          build/release/Qt*.dll

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -11,11 +11,13 @@ env:
   AQT_PLATFORM: msvc2019_64
 
 jobs:
+
   build:
 
     runs-on: windows-latest
 
     steps:
+
     - uses: actions/checkout@v3
 
     - name: Install MSVC
@@ -69,3 +71,17 @@ jobs:
         name: OpenSprite-latest
         path: |
           build/release/*
+
+    - name: ZIP executable artifacts
+      run: |
+        7z a -r OpenSprite-latest.zip .\build\release\*
+
+    - name: Publish release
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "latest"
+        prerelease: true
+        title: "Automatic Build"
+        files: |
+          OpenSprite-latest.zip

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   QT_VERSION: 6.2.0
-  PLATFORM: msvc2019_64
+  AQT_PLATFORM: msvc2019_64
 
 jobs:
   build:
@@ -33,11 +33,11 @@ jobs:
       run: |
         Write-Host 'Installing Qt ...'
         #aqt list-qt windows desktop --arch $Env:QT_VERSION
-        aqt install-qt windows desktop $Env:QT_VERSION "win64_${Env:PLATFORM}" -O C:\Qt
+        aqt install-qt windows desktop $Env:QT_VERSION "win64_${Env:AQT_PLATFORM}" -O C:\Qt
 
     - name: Run qmake
       run: |
         Write-Host 'Running qmake ...'
-        $Env:PATH = "C:\Qt\${Env:QT_VERSION}\${Env:PLATFORM}\bin;${Env:PATH}"
+        $Env:PATH = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}\bin;${Env:PATH}"
         #qmake --help
         qmake

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -41,13 +41,17 @@ jobs:
       run: |
         Write-Host 'Running qmake ...'
         $Env:PATH = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}\bin;${Env:PATH}"
-        qmake --help
-        Write-Host
+        # Generate MSBuild VC++ project
         qmake -Wall -tp vc OpenSprite.pro
 
     - name: List qmake artifacts
       run: |
         Get-ChildItem . -Recurse
+
+    - name: List Qt6 binaries
+      run: |
+        $src = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}\bin"
+        Get-ChildItem $src -Recurse
 
     - name: Build
       run: |
@@ -63,12 +67,11 @@ jobs:
     - name: List artifacts
       run: |
         Get-ChildItem . -Recurse
-        #Get-ChildItem C:\tmp -Recurse
 
     - name: Upload executable artifact
       uses: actions/upload-artifact@v3
       with:
-        name: OpenSprite-latest.zip
+        name: OpenSprite-latest
         path: |
           build/release/OpenSprite.exe
           build/release/Qt*.dll

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -9,6 +9,7 @@ on:
 env:
   QT_VERSION: 6.5.0
   AQT_PLATFORM: msvc2019_64
+  ARCHIVE_NAME: OpenSprite-win-amd64-latest
 
 jobs:
 
@@ -64,13 +65,13 @@ jobs:
     - name: Upload executable artifact
       uses: actions/upload-artifact@v3
       with:
-        name: OpenSprite-latest
+        name: ${{ env.ARCHIVE_NAME }}
         path: |
           build/release/*
 
     - name: ZIP executable artifacts
       run: |
-        7z a -r OpenSprite-latest.zip .\build\release\*
+        7z a -r "${Env:ARCHIVE_NAME}.zip" .\build\release\*
 
     - name: Publish release
       uses: "marvinpinto/action-automatic-releases@latest"
@@ -80,4 +81,4 @@ jobs:
         prerelease: true
         title: "Automatic Build"
         files: |
-          OpenSprite-latest.zip
+          "${{ env.ARCHIVE_NAME }}.zip"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -57,10 +57,6 @@ jobs:
 
         & "$windeployqt" --release --no-translations (Join-Path $pwd build\release)
 
-        #'Qt6Gui.dll', 'Qt6Core.dll', 'Qt6Widgets.dll' | ForEach-Object {
-        #  Copy-Item (Join-Path $src $_) .\build\release
-        #}
-
     - name: List artifacts
       run: |
         Get-ChildItem . -Recurse
@@ -82,6 +78,6 @@ jobs:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "latest"
         prerelease: true
-        title: "Automatic Build"
+        title: "Automatic Build ${{ github.sha }}"
         files: |
           OpenSprite-latest.zip

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -48,21 +48,20 @@ jobs:
       run: |
         Get-ChildItem . -Recurse
 
-    - name: List Qt6 binaries
-      run: |
-        $src = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}"
-        Get-ChildItem $src -Recurse
-
     - name: Build
       run: |
         msbuild OpenSprite.vcxproj -property:Configuration=Release
 
-    - name: Provision Qt6 libraries
+    - name: Provision runtime environment
       run: |
         $src = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}\bin"
-        'Qt6Gui.dll', 'Qt6Core.dll', 'Qt6Widgets.dll' | ForEach-Object {
-          Copy-Item (Join-Path $src $_) .\build\release
-        }
+        $windeployqt = Join-Path $src windeployqt.exe
+
+        & "$windeployqt" .\build\release
+
+        #'Qt6Gui.dll', 'Qt6Core.dll', 'Qt6Widgets.dll' | ForEach-Object {
+        #  Copy-Item (Join-Path $src $_) .\build\release
+        #}
 
     - name: List artifacts
       run: |
@@ -73,5 +72,4 @@ jobs:
       with:
         name: OpenSprite-latest
         path: |
-          build/release/OpenSprite.exe
-          build/release/Qt*.dll
+          build/release/*

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -30,10 +30,11 @@ jobs:
         aqt install-qt windows desktop $Env:QT_VERSION "win64_${Env:PLATFORM}" -O C:\Qt
 
     - name: List Dir
-      run: Get-ChildItem "C:\Qt\${Env:QT_VERSION}\${Env:PLATFORM}"
+      run: Get-ChildItem "C:\Qt\${Env:QT_VERSION}\${Env:PLATFORM}\bin"
 
     - name: Run qmake
       run: |
         Write-Host 'Running qmake ...'
-        $Env:PATH = ""C:\Qt\${Env:QT_VERSION}\${Env:PLATFORM}";${Env:PATH}"
+        $Env:PATH = "C:\Qt\${Env:QT_VERSION}\${Env:PLATFORM}\bin;${Env:PATH}"
         qmake --help
+        #qmake OpenSprite.pro

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -7,7 +7,7 @@ on:
 env:
   QT_VERSION: 6.2.0
   PLATFORM: msvc2019_64
-  QT_PATH: C:\Qt\${{ $QT_VERSION }}\${{ $PLATFORM }}
+  QT_PATH: C:\Qt\${{ env.QT_VERSION }}\${{ env.PLATFORM }}
 
 jobs:
   build:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -23,7 +23,6 @@ jobs:
       with:
         compiler: msvc
         vcvarsall: true
-        cmake: true
 
     - name: Download aqtinstall
       run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -41,3 +41,6 @@ jobs:
         $Env:PATH = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}\bin;${Env:PATH}"
         #qmake --help
         qmake
+
+    - name: List artifacts
+      run: Get-ChildItem . -Recurse

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -41,9 +41,11 @@ jobs:
       run: |
         Write-Host 'Running qmake ...'
         $Env:PATH = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}\bin;${Env:PATH}"
-        qmake --help
-        Write-Host
+        #qmake --help
+        #Write-Host
         qmake -makefile OpenSprite.pro
 
     - name: List artifacts
-      run: Get-ChildItem . -Recurse
+      run: |
+        Get-ChildItem . -Recurse
+        Get-ChildItem C:\tmp -Recurse

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -25,7 +25,14 @@ jobs:
         #aqt list-qt windows desktop --arch 6.2.0
         aqt install-qt windows desktop 6.2.0 win64_msvc2019_64 -O C:\Qt
 
+    - name: List Dir 1
+      run: Get-ChildItem C:\Qt
+
+    - name: List Dir 2
+      run: Get-ChildItem C:\Qt\6.2.0
+
     - name: Run qmake
       run: |
         Write-Host 'Running qmake ...'
+        $Env:PATH = "C:\Qt\6.2.0;$($Env:PATH)"
         qmake --help

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -16,6 +16,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Install MSVC
+      uses: aminya/setup-cpp@v1
+      with:
+        compiler: msvc
+        vcvarsall: true
+
     - name: Download aqtinstall
       run: |
         Write-Host 'Downloading  aqtinstall ...'

--- a/OpenSprite.pro
+++ b/OpenSprite.pro
@@ -10,10 +10,10 @@ CONFIG(debug, debug|release) {
     DESTDIR = build/release
 }
 
-OBJECTS_DIR = $$DESTDIR/.obj
-MOC_DIR = $$DESTDIR/.moc
-RCC_DIR = $$DESTDIR/.qrc
-UI_DIR = $$DESTDIR/.ui
+OBJECTS_DIR = $$DESTDIR/obj
+MOC_DIR = $$DESTDIR/moc
+RCC_DIR = $$DESTDIR/qrc
+UI_DIR = $$DESTDIR/ui
 
 # You can make your code fail to compile if it uses deprecated APIs.
 # In order to do so, uncomment the following line.

--- a/OpenSprite.pro
+++ b/OpenSprite.pro
@@ -4,6 +4,17 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
 CONFIG += c++11
 
+CONFIG(debug, debug|release) {
+    DESTDIR = build/debug
+} else {
+    DESTDIR = build/release
+}
+
+OBJECTS_DIR = $$DESTDIR/.obj
+MOC_DIR = $$DESTDIR/.moc
+RCC_DIR = $$DESTDIR/.qrc
+UI_DIR = $$DESTDIR/.ui
+
 # You can make your code fail to compile if it uses deprecated APIs.
 # In order to do so, uncomment the following line.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0

--- a/OpenSprite.pro
+++ b/OpenSprite.pro
@@ -10,11 +10,6 @@ CONFIG(debug, debug|release) {
     DESTDIR = build/release
 }
 
-OBJECTS_DIR = $$DESTDIR/obj
-MOC_DIR = $$DESTDIR/moc
-RCC_DIR = $$DESTDIR/qrc
-UI_DIR = $$DESTDIR/ui
-
 # You can make your code fail to compile if it uses deprecated APIs.
 # In order to do so, uncomment the following line.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 An open source sprite editor to generate sprites for the Commodore C64.
 
-This GPL3 project uses the open source version of [Qt](https://download.qt.io).
+This GPL3 project uses the open source version of the [Qt Framework](https://download.qt.io).

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 [![Windows C++ Qt Build](https://github.com/DarkLord79at/OpenSprite/actions/workflows/windows-build.yml/badge.svg)](https://github.com/DarkLord79at/OpenSprite/actions/workflows/windows-build.yml)
 
 An open source sprite editor to generate sprites for the Commodore C64.
+
+This GPL3 project uses the open source version of [Qt](https://download.qt.io).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # OpenSprite
 
-Windows Build (Experimental): [![Windows C++ Qt Build](https://github.com/DarkLord79at/OpenSprite/actions/workflows/windows-build.yml/badge.svg?branch=cicd)](https://github.com/DarkLord79at/OpenSprite/actions/workflows/windows-build.yml)
+Windows Build: [![Windows C++ Qt Build](https://github.com/DarkLord79at/OpenSprite/actions/workflows/windows-build.yml/badge.svg)](https://github.com/DarkLord79at/OpenSprite/actions/workflows/windows-build.yml)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenSprite
 
-[![Windows C++ Qt Build](actions/workflows/windows-build.yml/badge.svg)](actions/workflows/windows-build.yml)
+[![Windows C++ Qt Build](https://github.com/jowin202/OpenSprite/actions/workflows/windows-build.yml/badge.svg)](https://github.com/jowin202/OpenSprite/actions/workflows/windows-build.yml)
 
 An open source sprite editor to generate sprites for the Commodore C64.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenSprite
 
-[![Windows C++ Qt Build](/actions/workflows/windows-build.yml/badge.svg)](/actions/workflows/windows-build.yml)
+[![Windows C++ Qt Build](actions/workflows/windows-build.yml/badge.svg)](actions/workflows/windows-build.yml)
 
 An open source sprite editor to generate sprites for the Commodore C64.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # OpenSprite
 
-Windows Build (Experimental): ![Windows Build](https://github.com/DarkLord79at/OpenSprite/actions/workflows/windows-build.yml/badge.svg)
+Windows Build (Experimental): [![Windows C++ Qt Build](https://github.com/DarkLord79at/OpenSprite/actions/workflows/windows-build.yml/badge.svg?branch=cicd)](https://github.com/DarkLord79at/OpenSprite/actions/workflows/windows-build.yml)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # OpenSprite
 
-![Windows Build (Experimental)](https://github.com/DarkLord79at/OpenSprite/actions/workflows/windows-build.yml/badge.svg)
+Windows Build (Experimental): ![Windows Build](https://github.com/DarkLord79at/OpenSprite/actions/workflows/windows-build.yml/badge.svg)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenSprite
 
-[![Windows C++ Qt Build](https://github.com/DarkLord79at/OpenSprite/actions/workflows/windows-build.yml/badge.svg)](https://github.com/DarkLord79at/OpenSprite/actions/workflows/windows-build.yml)
+[![Windows C++ Qt Build](/actions/workflows/windows-build.yml/badge.svg)](/actions/workflows/windows-build.yml)
 
 An open source sprite editor to generate sprites for the Commodore C64.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # OpenSprite
 
-Windows Build: [![Windows C++ Qt Build](https://github.com/DarkLord79at/OpenSprite/actions/workflows/windows-build.yml/badge.svg)](https://github.com/DarkLord79at/OpenSprite/actions/workflows/windows-build.yml)
+[![Windows C++ Qt Build](https://github.com/DarkLord79at/OpenSprite/actions/workflows/windows-build.yml/badge.svg)](https://github.com/DarkLord79at/OpenSprite/actions/workflows/windows-build.yml)
+
+An open source sprite editor to generate sprites for the Commodore C64.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # OpenSprite
+
+![Windows Build (Experimental)](https://github.com/DarkLord79at/OpenSprite/actions/workflows/windows-build.yml/badge.svg)


### PR DESCRIPTION
Hi JoWin,

I've implemented a CI/CD pipeline using GitHub Workflows/Actions. Now on every push to the `main` or my experimental `cicd` branch, a zipped Windows version with all libraries will be automatically built and released under the `latest` tag.

IANAL but I added a remark and link to Qt for legal purposes just to be sure.

A minor modification of the project file was necessary  in order to consistently find and be able to package the build artifacts in a headless environment.

A large shoutout should go to [Hiroshi Miura's aqtinstall](https://github.com/miurahr/aqtinstall) for headless Qt installation without which this would have been impossible to do that easily.

The build badge should hopefully start to display properly after accepting the request - there is no way for user-agnostic/fork-relative linking unfortunately.

Regards,
DarkLord79at of VCC aka Markus