### PR TITLE
Added Quick Editor

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,78 @@
+name: Windows Build
+
+on:
+  push:
+    branches:
+      - main
+      - unstable
+
+env:
+  QT_VERSION: 6.5.0
+  AQT_PLATFORM: msvc2019_64
+  ARCHIVE_NAME: OpenSprite-win-amd64-latest
+
+jobs:
+
+  build:
+
+    permissions:
+      contents: write
+
+    runs-on: windows-latest
+
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - name: Install MSVC
+      uses: aminya/setup-cpp@v1
+      with:
+        compiler: msvc
+        vcvarsall: true
+
+    - name: Download aqtinstall
+      run: |
+        Write-Host 'Downloading  aqtinstall ...'
+        $src = 'https://github.com/miurahr/aqtinstall/releases/download/v3.1.6/aqt_x64_signed.exe'
+        $target = 'C:\Windows\System32\aqt.exe'
+        Invoke-WebRequest -Uri $src -OutFile $target
+    - name: Install Qt
+      run: |
+        Write-Host 'Installing Qt ...'
+        #aqt list-qt windows desktop --arch $Env:QT_VERSION
+        aqt install-qt windows desktop $Env:QT_VERSION "win64_${Env:AQT_PLATFORM}" -O C:\Qt
+    - name: Run qmake
+      run: |
+        Write-Host 'Running qmake ...'
+        $Env:PATH = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}\bin;${Env:PATH}"
+        # Generate MSBuild VC++ project
+        qmake -Wall -tp vc OpenSprite.pro
+    - name: Build
+      run: |
+        msbuild OpenSprite.vcxproj -property:Configuration=Release
+    - name: Provision runtime environment
+      run: |
+        $src = "C:\Qt\${Env:QT_VERSION}\${Env:AQT_PLATFORM}\bin"
+        $windeployqt = Join-Path $src windeployqt.exe
+        & "$windeployqt" --release --no-translations (Join-Path $pwd build\release)
+    - name: List artifacts
+      run: |
+        Get-ChildItem . -Recurse
+    - name: Upload executable artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.ARCHIVE_NAME }}
+        path: |
+          build/release/*
+    - name: ZIP executable artifacts
+      run: |
+        7z a -r "${Env:ARCHIVE_NAME}.zip" .\build\release\*
+    - name: Publish release
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "latest"
+        prerelease: true
+        title: "Automatic Build"
+        files: |
+          ${{ env.ARCHIVE_NAME }}.zip

--- a/OpenSprite.pro
+++ b/OpenSprite.pro
@@ -23,6 +23,7 @@ SOURCES += \
     main.cpp \
     mainwindow.cpp \
     palette.cpp \
+    quickeditor.cpp \
     rotations/rotationdialog.cpp \
     scale/scalingdialog.cpp \
     settingsdialog.cpp \
@@ -37,6 +38,7 @@ HEADERS += \
     fileio.h \
     mainwindow.h \
     palette.h \
+    quickeditor.h \
     rotations/rotationdialog.h \
     scale/scalingdialog.h \
     settingsdialog.h \

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -340,6 +340,47 @@ MainWindow::MainWindow(QWidget *parent)
         this->opt.show_numbers = val;
         this->ui->graphicsView->scene()->update();
     });
+
+    // ── Quick Editor ──────────────────────────────────────────────────────────
+    quickEditor = new QuickEditorWidget(this->ui->groupBox);
+    quickEditor->set_opt(&opt);
+    quickEditor->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+
+    // Shift all existing sidebar items down by one row to make room at row 0
+    QGridLayout *sideLayout = qobject_cast<QGridLayout*>(this->ui->groupBox->layout());
+    for (int i = sideLayout->count() - 1; i >= 0; i--) {
+        int r, c, rs, cs;
+        sideLayout->getItemPosition(i, &r, &c, &rs, &cs);
+        QLayoutItem *item = sideLayout->takeAt(i);
+        sideLayout->addItem(item, r + 1, c, rs, cs);
+    }
+    sideLayout->addWidget(quickEditor, 0, 0, 1, 3);
+
+    // Restore saved visibility state (default: off)
+    QSettings qeSettings;
+    bool qeEnabled = qeSettings.value("quickeditor_visible", false).toBool();
+    this->ui->actionQuickEditor->setChecked(qeEnabled);
+    quickEditor->setVisible(qeEnabled);
+
+    // Refresh Quick Editor when active sprite changes
+    connect(this->ui->graphicsView, &SpriteView::current_sprite_changed, this, [=](int) {
+        if (quickEditor->isVisible()) quickEditor->update();
+    });
+
+    // Sync Quick Editor whenever the scene updates (catches all edits + redraws)
+    connect(this->ui->graphicsView->scene(), &QGraphicsScene::changed, this, [=]() {
+        if (quickEditor->isVisible()) quickEditor->update();
+    });
+
+    // After a Quick Editor edit, sync the main scene
+    connect(quickEditor, &QuickEditorWidget::spriteEdited, this, [=]() {
+        this->ui->graphicsView->scene()->update();
+        if (!opt.sprite_list.isEmpty()) {
+            int id = opt.selection_from;
+            if (id >= 0 && id < opt.sprite_list.size())
+                opt.sprite_list.at(id)->update();
+        }
+    });
 }
 
 MainWindow::~MainWindow()
@@ -912,3 +953,11 @@ void MainWindow::on_actionScale_Dialog_triggered()
 
 }
 
+
+void MainWindow::on_actionQuickEditor_triggered()
+{
+    QSettings settings;
+    bool nowVisible = this->ui->actionQuickEditor->isChecked();
+    quickEditor->setVisible(nowVisible);
+    settings.setValue("quickeditor_visible", nowVisible);
+}

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -356,10 +356,19 @@ MainWindow::MainWindow(QWidget *parent)
     }
     sideLayout->addWidget(quickEditor, 0, 0, 1, 3);
 
+    // Create View > Quick Editor menu action entirely in code —
+    // no dependency on mainwindow.ui generating this action.
+    QMenu *viewMenu = this->menuBar()->addMenu(tr("View"));
+    actionQuickEditor = new QAction(tr("Quick Editor"), this);
+    actionQuickEditor->setCheckable(true);
+    viewMenu->addAction(actionQuickEditor);
+    connect(actionQuickEditor, &QAction::triggered,
+            this, &MainWindow::on_actionQuickEditor_triggered);
+
     // Restore saved visibility state (default: off)
     QSettings qeSettings;
     bool qeEnabled = qeSettings.value("quickeditor_visible", false).toBool();
-    this->ui->actionQuickEditor->setChecked(qeEnabled);
+    actionQuickEditor->setChecked(qeEnabled);
     quickEditor->setVisible(qeEnabled);
 
     // Refresh Quick Editor when active sprite changes
@@ -957,7 +966,7 @@ void MainWindow::on_actionScale_Dialog_triggered()
 void MainWindow::on_actionQuickEditor_triggered()
 {
     QSettings settings;
-    bool nowVisible = this->ui->actionQuickEditor->isChecked();
+    bool nowVisible = actionQuickEditor->isChecked();
     quickEditor->setVisible(nowVisible);
     settings.setValue("quickeditor_visible", nowVisible);
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -773,7 +773,7 @@ void MainWindow::on_actionAbout_triggered()
     QMessageBox msgBox(this);
     msgBox.setTextFormat(Qt::RichText);
     msgBox.setText(
-        "Version: 1.95 (10 / 2025)<br>Author: Johannes Winkler<br>License: GNU GPL License<br><a "
+        "Version: 1.95 (04 / 2026)<br>Author: Johannes Winkler<br>License: GNU GPL License<br><a "
         "href='https://github.com/jowin202/OpenSprite'>https://github.com/jowin202/OpenSprite</a>");
     msgBox.setStandardButtons(QMessageBox::Ok);
     msgBox.exec();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -358,7 +358,12 @@ MainWindow::MainWindow(QWidget *parent)
 
     // Create View > Quick Editor menu action entirely in code —
     // no dependency on mainwindow.ui generating this action.
-    QMenu *viewMenu = this->menuBar()->addMenu(tr("View"));
+    // Insert View menu before Help to get order: File Edit View Help
+    QAction *helpMenuAction = nullptr;
+    for (QAction *a : this->menuBar()->actions())
+        if (a->text() == tr("Help")) { helpMenuAction = a; break; }
+    QMenu *viewMenu = new QMenu(tr("View"), this);
+    this->menuBar()->insertMenu(helpMenuAction, viewMenu);
     actionQuickEditor = new QAction(tr("Quick Editor"), this);
     actionQuickEditor->setCheckable(true);
     viewMenu->addAction(actionQuickEditor);
@@ -370,6 +375,7 @@ MainWindow::MainWindow(QWidget *parent)
     bool qeEnabled = qeSettings.value("quickeditor_visible", false).toBool();
     actionQuickEditor->setChecked(qeEnabled);
     quickEditor->setVisible(qeEnabled);
+    this->ui->groupBox->setTitle(qeEnabled ? tr("Quick Editor and Options") : tr("Options"));
 
     // Refresh Quick Editor when active sprite changes
     connect(this->ui->graphicsView, &SpriteView::current_sprite_changed, this, [=](int) {
@@ -767,7 +773,7 @@ void MainWindow::on_actionAbout_triggered()
     QMessageBox msgBox(this);
     msgBox.setTextFormat(Qt::RichText);
     msgBox.setText(
-        "Version: 1.90 (10 / 2025)<br>Author: Johannes Winkler<br>License: GNU GPL License<br><a "
+        "Version: 1.95 (10 / 2025)<br>Author: Johannes Winkler<br>License: GNU GPL License<br><a "
         "href='https://github.com/jowin202/OpenSprite'>https://github.com/jowin202/OpenSprite</a>");
     msgBox.setStandardButtons(QMessageBox::Ok);
     msgBox.exec();
@@ -968,5 +974,6 @@ void MainWindow::on_actionQuickEditor_triggered()
     QSettings settings;
     bool nowVisible = actionQuickEditor->isChecked();
     quickEditor->setVisible(nowVisible);
+    this->ui->groupBox->setTitle(nowVisible ? tr("Quick Editor and Options") : tr("Options"));
     settings.setValue("quickeditor_visible", nowVisible);
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -17,6 +17,7 @@
 #include <QPushButton>
 
 #include "sprite.h"
+#include "quickeditor.h"
 
 class AnimationDialog;
 
@@ -115,9 +116,12 @@ private slots:
 
     void on_actionScale_Dialog_triggered();
 
+    void on_actionQuickEditor_triggered();
+
 private:
     Ui::MainWindow *ui;
     AnimationDialog *animation_dialog = 0;
+    QuickEditorWidget *quickEditor = nullptr;
 
     QButtonGroup leftradio;
     QButtonGroup rightradio;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -122,6 +122,7 @@ private:
     Ui::MainWindow *ui;
     AnimationDialog *animation_dialog = 0;
     QuickEditorWidget *quickEditor = nullptr;
+    QAction *actionQuickEditor = nullptr;
 
     QButtonGroup leftradio;
     QButtonGroup rightradio;

--- a/quickeditor.cpp
+++ b/quickeditor.cpp
@@ -1,0 +1,141 @@
+#include "quickeditor.h"
+
+QuickEditorWidget::QuickEditorWidget(QWidget *parent)
+    : QWidget(parent)
+{
+    setMouseTracking(true);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    setMinimumHeight(10);
+}
+
+QSize QuickEditorWidget::sizeHint() const
+{
+    int w = parentWidget() ? parentWidget()->width() : 240;
+    return QSize(w, heightForWidth(w));
+}
+
+// ── paint ────────────────────────────────────────────────────────────────────
+
+void QuickEditorWidget::paintEvent(QPaintEvent *)
+{
+    QPainter painter(this);
+    if (!opt || opt->sprite_list.isEmpty()) return;
+
+    int id = opt->selection_from;
+    if (id < 0 || id >= opt->sprite_list.size()) return;
+
+    const QJsonObject spriteObj =
+        opt->data.value("sprites").toArray().at(id).toObject();
+    const bool mc = spriteObj.value("mc_mode").toBool();
+
+    const int W = width();
+    const int H = height();
+
+    // Cell dimensions in widget space — always treat expand_x/expand_y as off
+    // Sprite pixel grid: 24 wide × 21 tall  (multicolor: 12 double-wide cols)
+    const double cw = mc ? (double)W / 12.0 : (double)W / 24.0;
+    const double ch = (double)H / 21.0;
+
+    auto getCol = [&](int colIndex) -> QColor {
+        return opt->col_list.at(colIndex);
+    };
+
+    Sprite *s = opt->sprite_list.at(id);
+
+    if (mc) {
+        for (int y = 0; y < 21; y++) {
+            for (int x = 0; x < 12; x++) {
+                QColor c;
+                bool b0 = s->get_bit(2*x,   y);
+                bool b1 = s->get_bit(2*x+1, y);
+                if      (!b0 && !b1) c = getCol(opt->data.value("background").toInt());
+                else if ( b0 && !b1) c = getCol(spriteObj.value("sprite_color").toInt());
+                else if (!b0 &&  b1) c = getCol(opt->data.value("mc1").toInt());
+                else                 c = getCol(opt->data.value("mc2").toInt());
+
+                painter.fillRect(QRectF(x*cw, y*ch, cw+1, ch+1), c);
+            }
+        }
+    } else {
+        for (int y = 0; y < 21; y++) {
+            for (int x = 0; x < 24; x++) {
+                QColor c = s->get_bit(x, y)
+                           ? getCol(spriteObj.value("sprite_color").toInt())
+                           : getCol(opt->data.value("background").toInt());
+                painter.fillRect(QRectF(x*cw, y*ch, cw+1, ch+1), c);
+            }
+        }
+    }
+
+    // Subtle border so it reads as an editor area
+    painter.setPen(QPen(Qt::darkGray, 1));
+    painter.drawRect(0, 0, W-1, H-1);
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+Sprite *QuickEditorWidget::activeSprite() const
+{
+    if (!opt || opt->sprite_list.isEmpty()) return nullptr;
+    int id = opt->selection_from;
+    if (id < 0 || id >= opt->sprite_list.size()) return nullptr;
+    return opt->sprite_list.at(id);
+}
+
+QPointF QuickEditorWidget::toSpriteLocal(QPoint wp) const
+{
+    // Sprite's own coordinate system: 240 wide × 210 tall (w=10, h=10, no expand).
+    // change_tile / flood_fill both use those dimensions, so we just scale.
+    return QPointF(wp.x() * 240.0 / width(),
+                   wp.y() * 210.0 / height());
+}
+
+// ── mouse ─────────────────────────────────────────────────────────────────────
+
+void QuickEditorWidget::mousePressEvent(QMouseEvent *ev)
+{
+    Sprite *s = activeSprite();
+    if (!s) return;
+
+    if (ev->button() == Qt::LeftButton)  s->set_left_pressed(true);
+    if (ev->button() == Qt::RightButton) s->set_right_pressed(true);
+
+    opt->undoDB.append(opt->data);
+
+    QPointF sp = toSpriteLocal(ev->pos());
+    if (opt->pen == PEN::DEFAULT)
+        s->change_tile(sp);
+    else
+        s->flood_fill(sp);
+
+    s->update();
+    update();
+    emit spriteEdited();
+}
+
+void QuickEditorWidget::mouseMoveEvent(QMouseEvent *ev)
+{
+    if (!(ev->buttons() & (Qt::LeftButton | Qt::RightButton))) return;
+    Sprite *s = activeSprite();
+    if (!s) return;
+
+    // Only DEFAULT pen tracks drag (flood fill is one-shot on press)
+    if (opt->pen == PEN::DEFAULT) {
+        QPointF sp = toSpriteLocal(ev->pos());
+        if (QRectF(0,0,width(),height()).contains(ev->pos()))
+            s->change_tile(sp);
+    }
+
+    s->update();
+    update();
+    emit spriteEdited();
+}
+
+void QuickEditorWidget::mouseReleaseEvent(QMouseEvent *ev)
+{
+    Sprite *s = activeSprite();
+    if (!s) return;
+
+    if (ev->button() == Qt::LeftButton)  s->set_left_pressed(false);
+    if (ev->button() == Qt::RightButton) s->set_right_pressed(false);
+}

--- a/quickeditor.cpp
+++ b/quickeditor.cpp
@@ -4,14 +4,24 @@ QuickEditorWidget::QuickEditorWidget(QWidget *parent)
     : QWidget(parent)
 {
     setMouseTracking(true);
-    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-    setMinimumHeight(10);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 }
 
 QSize QuickEditorWidget::sizeHint() const
 {
     int w = parentWidget() ? parentWidget()->width() : 240;
     return QSize(w, heightForWidth(w));
+}
+
+void QuickEditorWidget::resizeEvent(QResizeEvent *event)
+{
+    QWidget::resizeEvent(event);
+    // Enforce 24:21 aspect ratio every time the width changes.
+    // Using resizeEvent (not hasHeightForWidth alone) avoids the startup
+    // squeeze bug where the layout commits height before width is finalised.
+    int needed = width() * 21 / 24;
+    if (needed != height())
+        setFixedHeight(needed);
 }
 
 // ── paint ────────────────────────────────────────────────────────────────────
@@ -28,13 +38,12 @@ void QuickEditorWidget::paintEvent(QPaintEvent *)
         opt->data.value("sprites").toArray().at(id).toObject();
     const bool mc = spriteObj.value("mc_mode").toBool();
 
-    const int W = width();
-    const int H = height();
+    const double W = width();
+    const double H = height();
 
-    // Cell dimensions in widget space — always treat expand_x/expand_y as off
-    // Sprite pixel grid: 24 wide × 21 tall  (multicolor: 12 double-wide cols)
-    const double cw = mc ? (double)W / 12.0 : (double)W / 24.0;
-    const double ch = (double)H / 21.0;
+    // Cell dimensions — expand_x/expand_y always ignored in Quick Editor
+    const double cw = mc ? W / 12.0 : W / 24.0;
+    const double ch = H / 21.0;
 
     auto getCol = [&](int colIndex) -> QColor {
         return opt->col_list.at(colIndex);
@@ -42,17 +51,17 @@ void QuickEditorWidget::paintEvent(QPaintEvent *)
 
     Sprite *s = opt->sprite_list.at(id);
 
+    // ── pixels ───────────────────────────────────────────────────────────────
     if (mc) {
         for (int y = 0; y < 21; y++) {
             for (int x = 0; x < 12; x++) {
-                QColor c;
                 bool b0 = s->get_bit(2*x,   y);
                 bool b1 = s->get_bit(2*x+1, y);
+                QColor c;
                 if      (!b0 && !b1) c = getCol(opt->data.value("background").toInt());
                 else if ( b0 && !b1) c = getCol(spriteObj.value("sprite_color").toInt());
                 else if (!b0 &&  b1) c = getCol(opt->data.value("mc1").toInt());
                 else                 c = getCol(opt->data.value("mc2").toInt());
-
                 painter.fillRect(QRectF(x*cw, y*ch, cw+1, ch+1), c);
             }
         }
@@ -67,9 +76,32 @@ void QuickEditorWidget::paintEvent(QPaintEvent *)
         }
     }
 
-    // Subtle border so it reads as an editor area
+    // ── grid lines (mirrors Sprite::paint logic) ─────────────────────────────
+    if (opt->show_grid_lines) {
+        QPen pen;
+        pen.setColor(Qt::gray);
+        pen.setWidthF(0.5);
+        painter.setPen(pen);
+
+        // Horizontal lines — one per row
+        for (int y = 0; y < 21; y++)
+            painter.drawLine(QPointF(0, ch*y), QPointF(W, ch*y));
+
+        // Vertical lines — every two logical columns (mc double-pixel boundary)
+        for (int x = 0; x < 24; x += 2)
+            painter.drawLine(QPointF(cw * (mc ? x/2 : x), 0),
+                             QPointF(cw * (mc ? x/2 : x), H));
+
+        // Single-colour mode also gets odd-column lines
+        if (!mc) {
+            for (int x = 1; x < 24; x += 2)
+                painter.drawLine(QPointF(cw*x, 0), QPointF(cw*x, H));
+        }
+    }
+
+    // ── border ───────────────────────────────────────────────────────────────
     painter.setPen(QPen(Qt::darkGray, 1));
-    painter.drawRect(0, 0, W-1, H-1);
+    painter.drawRect(0, 0, (int)W-1, (int)H-1);
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -85,7 +117,6 @@ Sprite *QuickEditorWidget::activeSprite() const
 QPointF QuickEditorWidget::toSpriteLocal(QPoint wp) const
 {
     // Sprite's own coordinate system: 240 wide × 210 tall (w=10, h=10, no expand).
-    // change_tile / flood_fill both use those dimensions, so we just scale.
     return QPointF(wp.x() * 240.0 / width(),
                    wp.y() * 210.0 / height());
 }
@@ -119,10 +150,9 @@ void QuickEditorWidget::mouseMoveEvent(QMouseEvent *ev)
     Sprite *s = activeSprite();
     if (!s) return;
 
-    // Only DEFAULT pen tracks drag (flood fill is one-shot on press)
     if (opt->pen == PEN::DEFAULT) {
         QPointF sp = toSpriteLocal(ev->pos());
-        if (QRectF(0,0,width(),height()).contains(ev->pos()))
+        if (QRectF(0, 0, width(), height()).contains(ev->pos()))
             s->change_tile(sp);
     }
 

--- a/quickeditor.h
+++ b/quickeditor.h
@@ -1,0 +1,37 @@
+#ifndef QUICKEDITOR_H
+#define QUICKEDITOR_H
+
+#include <QWidget>
+#include <QPainter>
+#include <QMouseEvent>
+#include "sprite.h"
+
+class QuickEditorWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit QuickEditorWidget(QWidget *parent = nullptr);
+    void set_opt(options *opt) { this->opt = opt; }
+
+    QSize sizeHint() const override;
+    bool hasHeightForWidth() const override { return true; }
+    int  heightForWidth(int w) const override { return w * 21 / 24; }
+
+signals:
+    void spriteEdited();
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+    void mousePressEvent(QMouseEvent *ev) override;
+    void mouseMoveEvent(QMouseEvent *ev) override;
+    void mouseReleaseEvent(QMouseEvent *ev) override;
+
+private:
+    options *opt = nullptr;
+
+    // Map widget position → Sprite-local coordinate (240×210 space, no expand)
+    QPointF toSpriteLocal(QPoint widgetPos) const;
+    Sprite *activeSprite() const;
+};
+
+#endif // QUICKEDITOR_H

--- a/quickeditor.h
+++ b/quickeditor.h
@@ -22,6 +22,7 @@ signals:
 
 protected:
     void paintEvent(QPaintEvent *event) override;
+    void resizeEvent(QResizeEvent *event) override;
     void mousePressEvent(QMouseEvent *ev) override;
     void mouseMoveEvent(QMouseEvent *ev) override;
     void mouseReleaseEvent(QMouseEvent *ev) override;

--- a/sprite.h
+++ b/sprite.h
@@ -91,6 +91,10 @@ public:
     bool get_bit(int x, int y);
     void set_bit(int x, int y, bool value);
 
+    // Used by QuickEditorWidget to simulate mouse button state
+    void set_left_pressed(bool v)  { left_pressed  = v; }
+    void set_right_pressed(bool v) { right_pressed = v; }
+
     void slide_up(){
         bool tmp[24];
 


### PR DESCRIPTION
Adds an optional Quick Editor widget at the top of the Options sidebar (View -> Quick Editor, persistent setting, default off). The widget mirrors the active sprite at full sidebar width with 24:21 aspect ratio, supports all drawing tools (pen, flood fill, left/right button colors), and reflects editor grid lines when enabled. Edits in the Quick Editor are fully equivalent to editing in the sprite view and vice versa. The sidebar group box is retitled "Quick Editor and Options" while the panel is active. Also bumps version to 1.95.