### PR TITLE
Replacing drop-down list with a color picker, make color bar optional, move settings to view menu

### DIFF
--- a/OpenSprite.pro
+++ b/OpenSprite.pro
@@ -16,6 +16,7 @@ CONFIG(debug, debug|release) {
 
 SOURCES += \
     addbutton.cpp \
+    c64colorpicker.cpp \
     animations/animationdialog.cpp \
     animations/animationform.cpp \
     exportdialog.cpp \
@@ -32,6 +33,7 @@ SOURCES += \
 
 HEADERS += \
     addbutton.h \
+    c64colorpicker.h \
     animations/animationdialog.h \
     animations/animationform.h \
     exportdialog.h \

--- a/c64colorpicker.cpp
+++ b/c64colorpicker.cpp
@@ -46,10 +46,10 @@ void C64ColorPicker::setEnabled(bool enabled)
 
 int C64ColorPicker::patchH() const
 {
+    // Patch height = font height — makes each picker row as compact as a text line.
+    // patchW = 1.3 * patchH gives a slightly landscape rectangle like a C64 colour chip.
     QFontMetrics fm(font());
-    // Row height = font height + 2*gap on each side; patch fills the interior.
-    // The extra constant adds comfortable height so patches are clearly visible.
-    return fm.height() + 8;
+    return fm.height();
 }
 
 int C64ColorPicker::patchW() const { return qRound(patchH() * 1.3); }

--- a/c64colorpicker.cpp
+++ b/c64colorpicker.cpp
@@ -121,12 +121,14 @@ void C64ColorPicker::paintEvent(QPaintEvent *)
     }
 }
 
-// ── mouse ─────────────────────────────────────────────────────────────────────
-
 void C64ColorPicker::mousePressEvent(QMouseEvent *ev)
 {
     if (!m_enabled || m_colors.isEmpty()) return;
     if (ev->button() != Qt::LeftButton) return;
+
+    // Only trigger on the colour patch itself
+    QRect patch(patchX(), kGap, patchW(), patchH());
+    if (!patch.contains(ev->pos())) return;
 
     auto *popup = new C64ColorPopup(this);
     connect(popup, &C64ColorPopup::colorChosen, this, [=](int idx) {

--- a/c64colorpicker.cpp
+++ b/c64colorpicker.cpp
@@ -1,0 +1,233 @@
+#include "c64colorpicker.h"
+
+#include <QPainter>
+#include <QMouseEvent>
+#include <QFontMetrics>
+#include <QApplication>
+#include <QGuiApplication>
+#include <QScreen>
+#include <QKeyEvent>
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  C64ColorPicker
+// ═══════════════════════════════════════════════════════════════════════════════
+
+C64ColorPicker::C64ColorPicker(QWidget *parent)
+    : QWidget(parent)
+{
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    setFocusPolicy(Qt::StrongFocus);
+}
+
+void C64ColorPicker::setColors(const QList<QColor> &colors, const QStringList &names)
+{
+    m_colors = colors;
+    m_names  = names;
+    update();
+}
+
+void C64ColorPicker::setCurrentIndex(int idx)
+{
+    if (idx < 0 || idx >= m_colors.size()) return;
+    if (idx == m_index) return;
+    m_index = idx;
+    update();
+    emit currentIndexChanged(m_index);
+}
+
+void C64ColorPicker::setEnabled(bool enabled)
+{
+    m_enabled = enabled;
+    QWidget::setEnabled(enabled);
+    update();
+}
+
+// ── geometry ──────────────────────────────────────────────────────────────────
+
+int C64ColorPicker::patchH() const
+{
+    QFontMetrics fm(font());
+    // Row height = font height + 2*gap on each side; patch fills the interior.
+    // The extra constant adds comfortable height so patches are clearly visible.
+    return fm.height() + 8;
+}
+
+int C64ColorPicker::patchW() const { return qRound(patchH() * 1.3); }
+
+QSize C64ColorPicker::sizeHint() const
+{
+    QFontMetrics fm(font());
+    int h = patchH() + 2 * kGap;
+    int w = nameX() + fm.horizontalAdvance("Multi-Color 2") + 4;
+    return QSize(w, h);
+}
+
+void C64ColorPicker::resizeEvent(QResizeEvent *ev)
+{
+    QWidget::resizeEvent(ev);
+    // Lock height to our computed value so all pickers stay the same height
+    // regardless of what the layout tries to assign.
+    int needed = patchH() + 2 * kGap;
+    if (height() != needed)
+        setFixedHeight(needed);
+}
+
+// ── paint ─────────────────────────────────────────────────────────────────────
+
+void C64ColorPicker::paintEvent(QPaintEvent *)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, false);
+
+    const int ph  = patchH();
+    const int pw  = patchW();
+    const int px  = patchX();
+    const int nx  = nameX();
+    const int top = kGap;   // y where patch starts
+
+    // ── number (right-aligned, smaller font) ─────────────────────────────────
+    QFont numFont = font();
+    numFont.setPointSizeF(font().pointSizeF() * 0.80);
+    p.setFont(numFont);
+    p.setPen(m_enabled ? palette().color(QPalette::Text)
+                       : palette().color(QPalette::Disabled, QPalette::Text));
+    p.drawText(QRect(0, top, kNumWidth - 2, ph),
+               Qt::AlignRight | Qt::AlignVCenter,
+               QString::number(m_index));
+
+    // ── colour patch ─────────────────────────────────────────────────────────
+    QRect patch(px, top, pw, ph);
+    if (!m_colors.isEmpty() && m_index < m_colors.size()) {
+        QColor c = m_colors.at(m_index);
+        if (!m_enabled) c = c.darker(150);
+        p.fillRect(patch, c);
+    }
+    p.setPen(QPen(palette().color(QPalette::Mid), 1));
+    p.drawRect(patch.adjusted(0, 0, -1, -1));
+
+    // ── colour name (normal font, left-aligned) ───────────────────────────────
+    p.setFont(font());
+    p.setPen(m_enabled ? palette().color(QPalette::Text)
+                       : palette().color(QPalette::Disabled, QPalette::Text));
+    QString name = (!m_names.isEmpty() && m_index < m_names.size())
+                   ? m_names.at(m_index) : QString();
+    p.drawText(QRect(nx, top, width() - nx, ph),
+               Qt::AlignLeft | Qt::AlignVCenter, name);
+
+    // ── focus indicator ───────────────────────────────────────────────────────
+    if (hasFocus() && m_enabled) {
+        p.setPen(QPen(palette().color(QPalette::Highlight), 1, Qt::DotLine));
+        p.drawRect(rect().adjusted(1, 1, -2, -2));
+    }
+}
+
+// ── mouse ─────────────────────────────────────────────────────────────────────
+
+void C64ColorPicker::mousePressEvent(QMouseEvent *ev)
+{
+    if (!m_enabled || m_colors.isEmpty()) return;
+    if (ev->button() != Qt::LeftButton) return;
+
+    auto *popup = new C64ColorPopup(this);
+    connect(popup, &C64ColorPopup::colorChosen, this, [=](int idx) {
+        setCurrentIndex(idx);
+    });
+    popup->popup();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  C64ColorPopup
+// ═══════════════════════════════════════════════════════════════════════════════
+
+C64ColorPopup::C64ColorPopup(C64ColorPicker *owner)
+    : QFrame(owner, Qt::Popup | Qt::FramelessWindowHint)
+    , m_owner(owner)
+{
+    setFrameShape(QFrame::Box);
+    setLineWidth(1);
+    setFocusPolicy(Qt::StrongFocus);
+}
+
+int C64ColorPopup::cellW() const { return m_owner->patchW(); }
+int C64ColorPopup::cellH() const { return m_owner->patchH() + 2 * m_owner->kGap; }
+
+void C64ColorPopup::popup()
+{
+    resize(kCols * cellW(), kRows * cellH());
+
+    // Align popup so current colour's patch sits exactly over the picker's patch
+    QPoint pickerGlobal = m_owner->mapToGlobal(QPoint(0, 0));
+    int cur = m_owner->m_index;
+    int col = cur % kCols;
+    int row = cur / kCols;
+
+    int x = pickerGlobal.x() + m_owner->patchX() - col * cellW();
+    int y = pickerGlobal.y() + m_owner->kGap    - row * cellH();
+
+    // Keep on the screen the picker is actually on
+    QPoint pickerCenter = m_owner->mapToGlobal(m_owner->rect().center());
+    QScreen *screen = QGuiApplication::screenAt(pickerCenter);
+    if (!screen) screen = QGuiApplication::primaryScreen();
+    QRect sg = screen->availableGeometry();
+
+    x = qBound(sg.left(), x, sg.right()  - width());
+    y = qBound(sg.top(),  y, sg.bottom() - height());
+
+    move(x, y);
+    show();
+    setFocus();
+}
+
+void C64ColorPopup::paintEvent(QPaintEvent *)
+{
+    QPainter p(this);
+    const int cw  = cellW();
+    const int ch  = cellH();
+    const int gap = m_owner->kGap;
+    const int ph  = m_owner->patchH();
+
+    for (int i = 0; i < m_owner->m_colors.size() && i < kCols * kRows; i++) {
+        int col = i % kCols;
+        int row = i / kCols;
+
+        QRect cell(col * cw, row * ch, cw, ch);
+        p.fillRect(cell, palette().color(QPalette::Window));
+
+        QRect patch(col * cw, row * ch + gap, cw, ph);
+        p.fillRect(patch, m_owner->m_colors.at(i));
+
+        if (i == m_owner->m_index) {
+            p.setPen(QPen(Qt::white, 2));
+            p.drawRect(patch.adjusted(2, 2, -2, -2));
+            p.setPen(QPen(Qt::black, 1));
+            p.drawRect(patch.adjusted(1, 1, -1, -1));
+        } else {
+            p.setPen(QPen(palette().color(QPalette::Mid), 1));
+            p.drawRect(patch.adjusted(0, 0, -1, -1));
+        }
+    }
+}
+
+void C64ColorPopup::mousePressEvent(QMouseEvent *ev)
+{
+    if (!rect().contains(ev->pos())) {
+        close();
+        return;
+    }
+    const int cw = cellW();
+    const int ch = cellH();
+    int col = qBound(0, ev->pos().x() / cw, kCols - 1);
+    int row = qBound(0, ev->pos().y() / ch, kRows - 1);
+    int idx = row * kCols + col;
+    if (idx >= 0 && idx < m_owner->m_colors.size())
+        emit colorChosen(idx);
+    close();
+}
+
+void C64ColorPopup::focusOutEvent(QFocusEvent *) { close(); }
+
+void C64ColorPopup::keyPressEvent(QKeyEvent *ev)
+{
+    if (ev->key() == Qt::Key_Escape) close();
+    else QFrame::keyPressEvent(ev);
+}

--- a/c64colorpicker.cpp
+++ b/c64colorpicker.cpp
@@ -49,7 +49,7 @@ int C64ColorPicker::patchH() const
     // Patch height = font height — makes each picker row as compact as a text line.
     // patchW = 1.3 * patchH gives a slightly landscape rectangle like a C64 colour chip.
     QFontMetrics fm(font());
-    return qRound(fm.height() * 1.1);
+    return qRound(fm.height() * 1.155);
 }
 
 int C64ColorPicker::patchW() const { return qRound(patchH() * 1.3); }
@@ -150,8 +150,8 @@ C64ColorPopup::C64ColorPopup(C64ColorPicker *owner)
     setFocusPolicy(Qt::StrongFocus);
 }
 
-int C64ColorPopup::cellW() const { return m_owner->patchW() + 2; }  // 1px gap each side
-int C64ColorPopup::cellH() const { return m_owner->patchH() + 2; }  // 1px gap each side
+int C64ColorPopup::cellW() const { return m_owner->patchW(); }
+int C64ColorPopup::cellH() const { return m_owner->patchH(); }
 
 void C64ColorPopup::popup()
 {
@@ -163,8 +163,8 @@ void C64ColorPopup::popup()
     int col = cur % kCols;
     int row = cur / kCols;
 
-    int x = pickerGlobal.x() + m_owner->patchX() - col * cellW() - 1;
-    int y = pickerGlobal.y() + 1                - row * cellH();
+    int x = pickerGlobal.x() + m_owner->patchX() - col * cellW();
+    int y = pickerGlobal.y() + m_owner->kGap    - row * cellH();
 
     // Keep on the screen the picker is actually on
     QPoint pickerCenter = m_owner->mapToGlobal(m_owner->rect().center());
@@ -195,7 +195,7 @@ void C64ColorPopup::paintEvent(QPaintEvent *)
         QRect cell(col * cw, row * ch, cw, ch);
         p.fillRect(cell, palette().color(QPalette::Window));
 
-        QRect patch(col * cw + 1, row * ch + 1, cw - 2, ph);
+        QRect patch(col * cw, row * ch, cw, ph);
         p.fillRect(patch, m_owner->m_colors.at(i));
 
         if (i == m_owner->m_index) {

--- a/c64colorpicker.cpp
+++ b/c64colorpicker.cpp
@@ -49,7 +49,7 @@ int C64ColorPicker::patchH() const
     // Patch height = font height — makes each picker row as compact as a text line.
     // patchW = 1.3 * patchH gives a slightly landscape rectangle like a C64 colour chip.
     QFontMetrics fm(font());
-    return fm.height();
+    return qRound(fm.height() * 1.1);
 }
 
 int C64ColorPicker::patchW() const { return qRound(patchH() * 1.3); }
@@ -150,8 +150,8 @@ C64ColorPopup::C64ColorPopup(C64ColorPicker *owner)
     setFocusPolicy(Qt::StrongFocus);
 }
 
-int C64ColorPopup::cellW() const { return m_owner->patchW(); }
-int C64ColorPopup::cellH() const { return m_owner->patchH() + 2 * m_owner->kGap; }
+int C64ColorPopup::cellW() const { return m_owner->patchW() + 2; }  // 1px gap each side
+int C64ColorPopup::cellH() const { return m_owner->patchH() + 2; }  // 1px gap each side
 
 void C64ColorPopup::popup()
 {
@@ -163,8 +163,8 @@ void C64ColorPopup::popup()
     int col = cur % kCols;
     int row = cur / kCols;
 
-    int x = pickerGlobal.x() + m_owner->patchX() - col * cellW();
-    int y = pickerGlobal.y() + m_owner->kGap    - row * cellH();
+    int x = pickerGlobal.x() + m_owner->patchX() - col * cellW() - 1;
+    int y = pickerGlobal.y() + 1                - row * cellH();
 
     // Keep on the screen the picker is actually on
     QPoint pickerCenter = m_owner->mapToGlobal(m_owner->rect().center());
@@ -195,7 +195,7 @@ void C64ColorPopup::paintEvent(QPaintEvent *)
         QRect cell(col * cw, row * ch, cw, ch);
         p.fillRect(cell, palette().color(QPalette::Window));
 
-        QRect patch(col * cw, row * ch + gap, cw, ph);
+        QRect patch(col * cw + 1, row * ch + 1, cw - 2, ph);
         p.fillRect(patch, m_owner->m_colors.at(i));
 
         if (i == m_owner->m_index) {

--- a/c64colorpicker.h
+++ b/c64colorpicker.h
@@ -44,7 +44,7 @@ private:
     int           m_index   = 0;
     bool          m_enabled = true;
 
-    static constexpr int kGap      = 4;   // px gap above/below patch
+    static constexpr int kGap      = 2;   // px gap above/below patch
     static constexpr int kNumWidth = 24;  // fixed px for number column
     static constexpr int kNameGap  = 6;   // gap between patch and name
 

--- a/c64colorpicker.h
+++ b/c64colorpicker.h
@@ -1,0 +1,84 @@
+#ifndef C64COLORPICKER_H
+#define C64COLORPICKER_H
+
+#include <QWidget>
+#include <QFrame>
+#include <QList>
+#include <QColor>
+#include <QStringList>
+
+// ── C64ColorPicker ────────────────────────────────────────────────────────────
+// Displays:  "N"  ████  Color Name
+//   N        = colour index 0-15, right-aligned, slightly smaller font
+//   ████     = colour patch, height = row height - 2*kGap, width = 1.3 * height
+//   Color Name = left-aligned text
+//
+// Click anywhere on the widget opens a floating 4×4 colour grid popup.
+// Row height is font-metrics-based so patches never touch between pickers.
+
+class C64ColorPopup;
+
+class C64ColorPicker : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit C64ColorPicker(QWidget *parent = nullptr);
+
+    void setColors(const QList<QColor> &colors, const QStringList &names = {});
+    int  currentIndex() const { return m_index; }
+    void setCurrentIndex(int idx);
+    void setEnabled(bool enabled);
+
+signals:
+    void currentIndexChanged(int index);
+
+protected:
+    void paintEvent(QPaintEvent *) override;
+    void mousePressEvent(QMouseEvent *) override;
+    void resizeEvent(QResizeEvent *) override;
+    QSize sizeHint() const override;
+
+private:
+    QList<QColor> m_colors;
+    QStringList   m_names;
+    int           m_index   = 0;
+    bool          m_enabled = true;
+
+    static constexpr int kGap      = 4;   // px gap above/below patch
+    static constexpr int kNumWidth = 24;  // fixed px for number column
+    static constexpr int kNameGap  = 6;   // gap between patch and name
+
+    int patchH() const;
+    int patchW() const;
+    int patchX() const { return kNumWidth; }
+    int nameX()  const { return patchX() + patchW() + kNameGap; }
+
+    friend class C64ColorPopup;
+};
+
+// ── C64ColorPopup ─────────────────────────────────────────────────────────────
+class C64ColorPopup : public QFrame
+{
+    Q_OBJECT
+public:
+    explicit C64ColorPopup(C64ColorPicker *owner);
+    void popup();
+
+signals:
+    void colorChosen(int index);
+
+protected:
+    void paintEvent(QPaintEvent *) override;
+    void mousePressEvent(QMouseEvent *) override;
+    void focusOutEvent(QFocusEvent *) override;
+    void keyPressEvent(QKeyEvent *) override;
+
+private:
+    C64ColorPicker *m_owner;
+    static constexpr int kCols = 4;
+    static constexpr int kRows = 4;
+    int cellW() const;
+    int cellH() const;
+};
+
+#endif // C64COLORPICKER_H

--- a/main.cpp
+++ b/main.cpp
@@ -4,6 +4,8 @@
 
 int main(int argc, char *argv[])
 {
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
     QApplication a(argc, argv);
     QCoreApplication::setOrganizationName("jowin202");
     QCoreApplication::setOrganizationDomain("github.com/jowin202");

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -331,6 +331,11 @@ MainWindow::MainWindow(QWidget *parent)
         this->opt.show_numbers = val;
         this->ui->graphicsView->scene()->update();
     });
+    // Load sprite number size from settings
+    {
+        QSettings s;
+        this->opt.sprite_number_size = s.value("sprite_number_size", 100).toInt();
+    }
 
     // ── Quick Editor ──────────────────────────────────────────────────────────
     quickEditor = new QuickEditorWidget(this->ui->groupBox);
@@ -893,7 +898,11 @@ void MainWindow::on_actionPreferences_triggered()
 {
     SettingsDialog *dialog = new SettingsDialog(&opt);
     dialog->show();
-    connect(dialog, &SettingsDialog::finished, [=]() { this->ui->graphicsView->redraw(); });
+    connect(dialog, &SettingsDialog::finished, [=]() {
+        QSettings s;
+        this->opt.sprite_number_size = s.value("sprite_number_size", 100).toInt();
+        this->ui->graphicsView->redraw();
+    });
 }
 
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -202,12 +202,15 @@ MainWindow::MainWindow(QWidget *parent)
     });
     connect(this->ui->combo_overlay_color,
             qOverload<int>(&C64ColorPicker::currentIndexChanged), this, [=](int index) {
+        // Overlay colour is the sprite_color of the next sprite (id+1).
         QJsonArray sprites_array = opt.data.value("sprites").toArray();
         for (int i = opt.selection_from; i <= opt.selection_to; i++) {
-            QJsonObject current_sprite_obj = opt.data.value("sprites").toArray().at(i).toObject();
-            current_sprite_obj.insert("overlay_color", index);
-            sprites_array.removeAt(i);
-            sprites_array.insert(i, current_sprite_obj);
+            int nextIdx = i + 1;
+            if (nextIdx >= sprites_array.size()) continue;
+            QJsonObject next_sprite_obj = sprites_array.at(nextIdx).toObject();
+            next_sprite_obj.insert("sprite_color", index);
+            sprites_array.removeAt(nextIdx);
+            sprites_array.insert(nextIdx, next_sprite_obj);
         }
         opt.data.insert("sprites", sprites_array);
         this->ui->graphicsView->scene()->update();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -768,7 +768,7 @@ void MainWindow::on_actionAbout_triggered()
     QMessageBox msgBox(this);
     msgBox.setTextFormat(Qt::RichText);
     msgBox.setText(
-        "Version: 1.95 (04 / 2026)<br>Author:<br>Johannes Winkler<br>Wilfried Elmenreich<br>License: GNU GPL License<br><a "
+        "Version: 1.97 (04 / 2026)<br>Author:<br>Johannes Winkler<br>Wilfried Elmenreich<br>License: GNU GPL License<br><a "
         "href='https://github.com/jowin202/OpenSprite'>https://github.com/jowin202/OpenSprite</a>");
     msgBox.setStandardButtons(QMessageBox::Ok);
     msgBox.exec();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -164,61 +164,52 @@ MainWindow::MainWindow(QWidget *parent)
         this->import(file);
     });
 
-    //combos
-    for (int i = 0; i < 16; i++) {
-        this->ui->combo_transparent->addItem(opt.col_names.at(i));
-        this->ui->combo_transparent->setItemIcon(i, this->createIconFromColor(opt.col_list.at(i)));
-        this->ui->combo_sprite_col->addItem(opt.col_names.at(i));
-        this->ui->combo_sprite_col->setItemIcon(i, this->createIconFromColor(opt.col_list.at(i)));
-        this->ui->combo_multicol_1->addItem(opt.col_names.at(i));
-        this->ui->combo_multicol_1->setItemIcon(i, this->createIconFromColor(opt.col_list.at(i)));
-        this->ui->combo_multicol_2->addItem(opt.col_names.at(i));
-        this->ui->combo_multicol_2->setItemIcon(i, this->createIconFromColor(opt.col_list.at(i)));
-        this->ui->combo_overlay_color->addItem(opt.col_names.at(i));
-        this->ui->combo_overlay_color->setItemIcon(i, this->createIconFromColor(opt.col_list.at(i)));
-    }
-    connect(this->ui->combo_transparent, &QComboBox::currentIndexChanged, this, [=](int index) {
+    // Populate colour pickers with colours and names
+    auto setPickerColors = [&](C64ColorPicker *p) {
+        p->setColors(opt.col_list, opt.col_names);
+    };
+    setPickerColors(this->ui->combo_transparent);
+    setPickerColors(this->ui->combo_sprite_col);
+    setPickerColors(this->ui->combo_multicol_1);
+    setPickerColors(this->ui->combo_multicol_2);
+    setPickerColors(this->ui->combo_overlay_color);
+    connect(this->ui->combo_transparent,
+            qOverload<int>(&C64ColorPicker::currentIndexChanged), this, [=](int index) {
         opt.data.insert("background", index);
         this->ui->graphicsView->redraw();
     });
-    connect(this->ui->combo_sprite_col, &QComboBox::currentIndexChanged, this, [=](int index) {
-
-        for (int i = opt.selection_from; i <= opt.selection_to; i++)
-        {
-            QJsonObject current_sprite_obj
-                = opt.data.value("sprites").toArray().at(i).toObject();
+    connect(this->ui->combo_sprite_col,
+            qOverload<int>(&C64ColorPicker::currentIndexChanged), this, [=](int index) {
+        QJsonArray sprites_array = opt.data.value("sprites").toArray();
+        for (int i = opt.selection_from; i <= opt.selection_to; i++) {
+            QJsonObject current_sprite_obj = opt.data.value("sprites").toArray().at(i).toObject();
             current_sprite_obj.insert("sprite_color", index);
-            QJsonArray sprites_array = opt.data.value("sprites").toArray();
             sprites_array.removeAt(i);
             sprites_array.insert(i, current_sprite_obj);
-            opt.data.insert("sprites", sprites_array);
         }
-
+        opt.data.insert("sprites", sprites_array);
         this->ui->graphicsView->scene()->update();
     });
-    connect(this->ui->combo_multicol_1, &QComboBox::currentIndexChanged, this, [=](int index) {
+    connect(this->ui->combo_multicol_1,
+            qOverload<int>(&C64ColorPicker::currentIndexChanged), this, [=](int index) {
         opt.data.insert("mc1", index);
         this->ui->graphicsView->scene()->update();
     });
-    connect(this->ui->combo_multicol_2, &QComboBox::currentIndexChanged, this, [=](int index) {
+    connect(this->ui->combo_multicol_2,
+            qOverload<int>(&C64ColorPicker::currentIndexChanged), this, [=](int index) {
         opt.data.insert("mc2", index);
         this->ui->graphicsView->scene()->update();
     });
-    connect(this->ui->combo_overlay_color, &QComboBox::currentIndexChanged, this, [=](int index) {
-
-        for (int i = opt.selection_from; i <= opt.selection_to; i++)
-        {
-            if (this->opt.data.value("sprites").toArray().count() > i + 1) {
-                QJsonObject current_sprite_obj
-                    = opt.data.value("sprites").toArray().at(i + 1).toObject();
-                current_sprite_obj.insert("sprite_color", index);
-                QJsonArray sprites_array = opt.data.value("sprites").toArray();
-                sprites_array.removeAt(i + 1);
-                sprites_array.insert(i + 1, current_sprite_obj);
-                opt.data.insert("sprites", sprites_array);
-            }
+    connect(this->ui->combo_overlay_color,
+            qOverload<int>(&C64ColorPicker::currentIndexChanged), this, [=](int index) {
+        QJsonArray sprites_array = opt.data.value("sprites").toArray();
+        for (int i = opt.selection_from; i <= opt.selection_to; i++) {
+            QJsonObject current_sprite_obj = opt.data.value("sprites").toArray().at(i).toObject();
+            current_sprite_obj.insert("overlay_color", index);
+            sprites_array.removeAt(i);
+            sprites_array.insert(i, current_sprite_obj);
         }
-
+        opt.data.insert("sprites", sprites_array);
         this->ui->graphicsView->scene()->update();
     });
 
@@ -382,7 +373,14 @@ MainWindow::MainWindow(QWidget *parent)
                 opt.sprite_list.at(id)->update();
         }
     });
+
+    // ── Color Bar ────────────────────────────────────────────────────────
+    QSettings cbSettings;
+    bool cbEnabled = cbSettings.value("colorbar_visible", false).toBool();
+    this->ui->actionColor_Bar->setChecked(cbEnabled);
+    this->ui->label_palette->setVisible(cbEnabled);
 }
+
 
 MainWindow::~MainWindow()
 {
@@ -968,3 +966,11 @@ void MainWindow::on_actionQuick_Editor_triggered()
     settings.setValue("quickeditor_visible", nowVisible);
 }
 
+
+void MainWindow::on_actionColor_Bar_triggered()
+{
+    QSettings settings;
+    bool nowVisible = this->ui->actionColor_Bar->isChecked();
+    this->ui->label_palette->setVisible(nowVisible);
+    settings.setValue("colorbar_visible", nowVisible);
+}

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -17,6 +17,7 @@
 #include <QPushButton>
 
 #include "sprite.h"
+#include "c64colorpicker.h"
 #include "quickeditor.h"
 
 class AnimationDialog;
@@ -117,6 +118,7 @@ private slots:
     void on_actionScale_Dialog_triggered();
 
     void on_actionQuick_Editor_triggered();
+    void on_actionColor_Bar_triggered();
 
 private:
     Ui::MainWindow *ui;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -88,6 +88,12 @@
          </item>
          <item row="4" column="0" colspan="3">
           <layout class="QGridLayout" name="gridLayout_5">
+           <property name="verticalSpacing">
+            <number>5</number>
+           </property>
+           <property name="horizontalSpacing">
+            <number>8</number>
+           </property>
            <item row="6" column="3">
             <widget class="QRadioButton" name="radio_overlay_color_right">
              <property name="enabled">
@@ -98,19 +104,7 @@
              </property>
             </widget>
            </item>
-           <item row="6" column="4">
-            <widget class="QLabel" name="label_9">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Overlay Color</string>
-             </property>
-            </widget>
-           </item>
+
            <item row="7" column="2">
             <widget class="QRadioButton" name="radio_overlay_transparent_left">
              <property name="enabled">
@@ -121,55 +115,13 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="4">
-            <widget class="QLabel" name="label_2">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Transparent</string>
-             </property>
+
+
+           <item row="3" column="4" colspan="2">
+            <widget class="C64ColorPicker" name="combo_sprite_col">
             </widget>
            </item>
-           <item row="5" column="4">
-            <widget class="QLabel" name="label_5">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Multi-Color 2</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="5">
-            <widget class="QComboBox" name="combo_sprite_col">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="4">
-            <widget class="QLabel" name="label_4">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Multi-Color 1</string>
-             </property>
-            </widget>
-           </item>
+
            <item row="5" column="3">
             <widget class="QRadioButton" name="radio_mc2_right">
              <property name="text">
@@ -177,14 +129,8 @@
              </property>
             </widget>
            </item>
-           <item row="4" column="5">
-            <widget class="QComboBox" name="combo_multicol_1">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
+           <item row="4" column="4" colspan="2">
+            <widget class="C64ColorPicker" name="combo_multicol_1">
             </widget>
            </item>
            <item row="5" column="1">
@@ -302,29 +248,11 @@
              </property>
             </widget>
            </item>
-           <item row="5" column="5">
-            <widget class="QComboBox" name="combo_multicol_2">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
+           <item row="5" column="4" colspan="2">
+            <widget class="C64ColorPicker" name="combo_multicol_2">
             </widget>
            </item>
-           <item row="3" column="4">
-            <widget class="QLabel" name="label_3">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Sprite Color</string>
-             </property>
-            </widget>
-           </item>
+
            <item row="4" column="1">
             <widget class="QLabel" name="label_17">
              <property name="maximumSize">
@@ -384,29 +312,11 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="5">
-            <widget class="QComboBox" name="combo_transparent">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
+           <item row="2" column="4" colspan="2">
+            <widget class="C64ColorPicker" name="combo_transparent">
             </widget>
            </item>
-           <item row="7" column="4">
-            <widget class="QLabel" name="label_10">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Overlay Transparent</string>
-             </property>
-            </widget>
-           </item>
+
            <item row="6" column="2">
             <widget class="QRadioButton" name="radio_overlay_color_left">
              <property name="enabled">
@@ -427,16 +337,10 @@
              </property>
             </widget>
            </item>
-           <item row="6" column="5">
-            <widget class="QComboBox" name="combo_overlay_color">
+           <item row="6" column="4" colspan="2">
+            <widget class="C64ColorPicker" name="combo_overlay_color">
              <property name="enabled">
               <bool>false</bool>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
              </property>
             </widget>
            </item>
@@ -652,6 +556,7 @@
      <string>View</string>
     </property>
     <addaction name="actionQuick_Editor"/>
+    <addaction name="actionColor_Bar"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuEdit"/>
@@ -1043,8 +948,21 @@
     <string>Quick Editor</string>
    </property>
   </action>
+  <action name="actionColor_Bar">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Color Bar</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>C64ColorPicker</class>
+   <extends>QWidget</extends>
+   <header>c64colorpicker.h</header>
+  </customwidget>
   <customwidget>
    <class>SpriteView</class>
    <extends>QGraphicsView</extends>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -89,7 +89,7 @@
          <item row="4" column="0" colspan="3">
           <layout class="QGridLayout" name="gridLayout_5">
            <property name="verticalSpacing">
-            <number>5</number>
+            <number>8</number>
            </property>
            <property name="horizontalSpacing">
             <number>8</number>
@@ -370,6 +370,48 @@
              </property>
             </widget>
            </item>
+           <item row="2" column="6">
+            <widget class="QLabel" name="label_transparent_name">
+             <property name="text">
+              <string>Transparent</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="6">
+            <widget class="QLabel" name="label_sprite_col_name">
+             <property name="text">
+              <string>Sprite Color</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="6">
+            <widget class="QLabel" name="label_mc1_name">
+             <property name="text">
+              <string>Multi-Color 1</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="6">
+            <widget class="QLabel" name="label_mc2_name">
+             <property name="text">
+              <string>Multi-Color 2</string>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="6">
+            <widget class="QLabel" name="label_oc_name">
+             <property name="text">
+              <string>Overlay Color</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="6">
+            <widget class="QLabel" name="label_ot_name">
+             <property name="text">
+              <string>Overlay Transparent</string>
+             </property>
+            </widget>
+           </item>
           </layout>
          </item>
          <item row="9" column="0">
@@ -500,7 +542,6 @@
     <addaction name="actionExport_as"/>
     <addaction name="separator"/>
     <addaction name="actionAnimations_Editor"/>
-    <addaction name="actionPreferences"/>
     <addaction name="separator"/>
     <addaction name="actionZoomIn"/>
     <addaction name="actionZoomOut"/>
@@ -557,6 +598,8 @@
     </property>
     <addaction name="actionQuick_Editor"/>
     <addaction name="actionColor_Bar"/>
+    <addaction name="separator"/>
+    <addaction name="actionPreferences"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuEdit"/>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -48,6 +48,9 @@
          <string>Options</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_4">
+         <property name="verticalSpacing">
+          <number>2</number>
+         </property>
          <item row="1" column="0">
           <widget class="QCheckBox" name="check_exp_x">
            <property name="text">
@@ -89,7 +92,7 @@
          <item row="4" column="0" colspan="3">
           <layout class="QGridLayout" name="gridLayout_5">
            <property name="verticalSpacing">
-            <number>8</number>
+            <number>2</number>
            </property>
            <property name="horizontalSpacing">
             <number>8</number>
@@ -117,7 +120,7 @@
            </item>
 
 
-           <item row="3" column="4" colspan="2">
+           <item row="3" column="5" colspan="2">
             <widget class="C64ColorPicker" name="combo_sprite_col">
             </widget>
            </item>
@@ -129,7 +132,7 @@
              </property>
             </widget>
            </item>
-           <item row="4" column="4" colspan="2">
+           <item row="4" column="5" colspan="2">
             <widget class="C64ColorPicker" name="combo_multicol_1">
             </widget>
            </item>
@@ -248,7 +251,7 @@
              </property>
             </widget>
            </item>
-           <item row="5" column="4" colspan="2">
+           <item row="5" column="5" colspan="2">
             <widget class="C64ColorPicker" name="combo_multicol_2">
             </widget>
            </item>
@@ -312,7 +315,7 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="4" colspan="2">
+           <item row="2" column="5" colspan="2">
             <widget class="C64ColorPicker" name="combo_transparent">
             </widget>
            </item>
@@ -337,7 +340,7 @@
              </property>
             </widget>
            </item>
-           <item row="6" column="4" colspan="2">
+           <item row="6" column="5" colspan="2">
             <widget class="C64ColorPicker" name="combo_overlay_color">
              <property name="enabled">
               <bool>false</bool>
@@ -370,42 +373,42 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="6">
+           <item row="2" column="4">
             <widget class="QLabel" name="label_transparent_name">
              <property name="text">
               <string>Transparent</string>
              </property>
             </widget>
            </item>
-           <item row="3" column="6">
+           <item row="3" column="4">
             <widget class="QLabel" name="label_sprite_col_name">
              <property name="text">
               <string>Sprite Color</string>
              </property>
             </widget>
            </item>
-           <item row="4" column="6">
+           <item row="4" column="4">
             <widget class="QLabel" name="label_mc1_name">
              <property name="text">
               <string>Multi-Color 1</string>
              </property>
             </widget>
            </item>
-           <item row="5" column="6">
+           <item row="5" column="4">
             <widget class="QLabel" name="label_mc2_name">
              <property name="text">
               <string>Multi-Color 2</string>
              </property>
             </widget>
            </item>
-           <item row="6" column="6">
+           <item row="6" column="4">
             <widget class="QLabel" name="label_oc_name">
              <property name="text">
               <string>Overlay Color</string>
              </property>
             </widget>
            </item>
-           <item row="7" column="6">
+           <item row="7" column="4">
             <widget class="QLabel" name="label_ot_name">
              <property name="text">
               <string>Overlay Transparent</string>

--- a/settingsdialog.cpp
+++ b/settingsdialog.cpp
@@ -15,6 +15,9 @@ SettingsDialog::SettingsDialog(options *opt, QWidget *parent)
     this->ui->spin_vertical_spacing->setValue(settings.value("sprite_spacing_y").toInt());
     this->ui->spin_sprites_per_row->setValue(settings.value("sprites_per_row").toInt());
 
+    this->ui->spin_sprite_number_size->setValue(
+        settings.value("sprite_number_size", 100).toInt());
+
     bool auto_mode = settings.value("sprites_per_row_auto", false).toBool();
     this->ui->check_sprites_per_row_auto->setChecked(auto_mode);
     this->ui->spin_sprites_per_row->setEnabled(!auto_mode);
@@ -40,6 +43,8 @@ void SettingsDialog::on_button_ok_clicked()
     settings.setValue("sprite_spacing_y", this->ui->spin_vertical_spacing->value());
     settings.setValue("sprites_per_row", this->ui->spin_sprites_per_row->value());
     settings.setValue("sprites_per_row_auto", this->ui->check_sprites_per_row_auto->isChecked());
+    settings.setValue("sprite_number_size",
+        this->ui->spin_sprite_number_size->value());
 
     if (select_color.isValid())
         settings.setValue("selection_color", select_color.red() << 16 | select_color.green() << 8 | select_color.blue());
@@ -80,6 +85,7 @@ void SettingsDialog::on_button_defaults_clicked()
     settings.setValue("sprite_spacing_y", 30);
     settings.setValue("sprites_per_row", 4);
     settings.setValue("sprites_per_row_auto", false);
+    settings.setValue("sprite_number_size", 100);
     emit finished();
     this->close();
 }

--- a/settingsdialog.ui
+++ b/settingsdialog.ui
@@ -161,6 +161,38 @@
        </property>
       </widget>
      </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_numsize">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Sprite Number Size (%):</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QSpinBox" name="spin_sprite_number_size">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimum">
+        <number>10</number>
+       </property>
+       <property name="maximum">
+        <number>100</number>
+       </property>
+       <property name="value">
+        <number>100</number>
+       </property>
+      </widget>
+     </item>
      <item row="3" column="1">
       <widget class="QPushButton" name="button_selection_color">
        <property name="text">

--- a/sprite.cpp
+++ b/sprite.cpp
@@ -134,14 +134,30 @@ void Sprite::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QW
 
     if (opt->show_numbers)
     {
-
         int w = 10 * (expand_y ? 0.5 : 1);
         int h = 10 * (expand_x ? 0.5 : 1);
 
+        int pct = opt->sprite_number_size;  // 1..100
+        // Font size scales with percentage
+        int fontPx = qRound(qMin(0.8 * 24 * w, 0.8 * 21 * h) * pct / 100.0);
+        fontPx = qMax(fontPx, 6);
+
         QFont font = painter->font();
-        font.setPixelSize(qMin(0.8*24*w, 0.8*21*h));
+        font.setPixelSize(fontPx);
         painter->setFont(font);
-        painter->drawText(0,0,24*w,21*h, Qt::AlignVCenter | Qt::AlignHCenter, QString::number(id));
+
+        if (pct >= 100) {
+            // Full size: centered over the whole sprite
+            painter->drawText(0, 0, 24*w, 21*h,
+                              Qt::AlignVCenter | Qt::AlignHCenter,
+                              QString::number(id));
+        } else {
+            // Smaller: top-left aligned with small margin
+            int margin = 2;
+            painter->drawText(margin, margin, 24*w - margin, 21*h - margin,
+                              Qt::AlignTop | Qt::AlignLeft,
+                              QString::number(id));
+        }
     }
 
 

--- a/sprite.cpp
+++ b/sprite.cpp
@@ -152,9 +152,10 @@ void Sprite::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QW
                               Qt::AlignVCenter | Qt::AlignHCenter,
                               QString::number(id));
         } else {
-            // Smaller: top-left aligned with small margin
-            int margin = 2;
-            painter->drawText(margin, margin, 24*w - margin, 21*h - margin,
+            // Smaller: top-left aligned, indented by half a pixel-cell width
+            int marginTop  = 2;
+            int marginLeft = w / 2;
+            painter->drawText(marginLeft, marginTop, 24*w - marginLeft, 21*h - marginTop,
                               Qt::AlignTop | Qt::AlignLeft,
                               QString::number(id));
         }

--- a/sprite.cpp
+++ b/sprite.cpp
@@ -152,12 +152,13 @@ void Sprite::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QW
                               Qt::AlignVCenter | Qt::AlignHCenter,
                               QString::number(id));
         } else {
-            // Smaller: top-left aligned, indented by half a pixel-cell width
-            int marginTop  = 2;
+            // Smaller: top-left, indented half a pixel-cell from left.
+            // Use explicit baseline to avoid Qt's internal descent offset.
+            QFontMetrics fm(painter->font());
             int marginLeft = w / 2;
-            painter->drawText(marginLeft, marginTop, 24*w - marginLeft, 21*h - marginTop,
-                              Qt::AlignTop | Qt::AlignLeft,
-                              QString::number(id));
+            int marginTop  = 2;
+            int baseline   = marginTop + fm.ascent();
+            painter->drawText(marginLeft, baseline, QString::number(id));
         }
     }
 

--- a/sprite.h
+++ b/sprite.h
@@ -29,6 +29,7 @@ struct options {
     SpriteView *spriteview;
     bool show_grid_lines = true;
     bool show_numbers = false;
+    int  sprite_number_size = 100; // percentage: 100 = full sprite, smaller = top-left aligned
 
 
     //auto export


### PR DESCRIPTION
The five color selection drop-downs (Transparent, Sprite Color, Multi-Color 1/2, Overlay Color) are replaced with a compact custom widget showing the color index, a color patch, and the color name. Clicking the patch opens a 4×4 floating grid for selection. The color bar below the controls is now toggled via View -> Color Bar (off by default), and Settings has been moved from the File menu to View, as it contains View-related information.